### PR TITLE
Basic protection against illegal requests

### DIFF
--- a/application/connections/websocket_server.py
+++ b/application/connections/websocket_server.py
@@ -67,8 +67,12 @@ class Server:
 
                 elif req.get("operation") == "handshake":
                     bot_count = req["data"].get("useraccounts", 1)
-                    self.__client_count += bot_count
-                    print(f"{bot_count} New Client(s) connected! New bot count: {self.__client_count}")
+                    if bot_count < 0 or bot_count > 100:
+                      print(f"Ignoring illegal connection: A client pretends to have {bot_count} bots.")
+                      bot_count = 0
+                    else:
+                      self.__client_count += bot_count
+                      print(f"{bot_count} New Client(s) connected! New bot count: {self.__client_count}")
 
                 elif req.get("operation") == "get-botcount":
                     await socket.send(json.dumps({"amount": self.__client_count}))


### PR DESCRIPTION
Aktuell können clients beliebige Zahlen als Bot-Anzahl angeben. Wenn wir auch nur ansatzweise verlässliche Statistiken haben wollen, brauchen wir gegen solche requests etwas Schutz. Dafür ist dieser kleine PR:

* Requests, die eine negative oder zu große (>100) Anzahl bots angeben, werden ignoriert
* Dazu wird auch eine Lognachricht ausgegeben, damit man notfalls false positives erkennen kann

Der Schutz ist hoffentlich nicht nötig, aber sicher ist sicher.
Es ist auch lange nicht das einzige, was der Server noch brauchen könnte.